### PR TITLE
Push current branch downstream

### DIFF
--- a/git_sync/__init__.py
+++ b/git_sync/__init__.py
@@ -70,4 +70,4 @@ def main() -> None:
     else:
         check_call(["git", "fetch", "--all"])
     fast_forward_to_upstream(b for b in branches if b.name != current_branch)
-    fast_forward_to_downstream(b for b in branches if b.name != current_branch)
+    fast_forward_to_downstream(branches)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-sync"
-version = "0.1.0"
+version = "0.1.1"
 description = "Synchronize local git repo with remotes"
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 


### PR DESCRIPTION
The current branch was being excluded from the list of branches to fast-forward to downstream. This was a copy-paste error from the equivalent fast-forward to upstream, where it is excluded because we use `pull` to update the current branch.

This fixes #3.