### PR TITLE
Use plumbing command git-for-each-ref

### DIFF
--- a/git_sync/__init__.py
+++ b/git_sync/__init__.py
@@ -21,7 +21,9 @@ def get_default_push_remote() -> Optional[bytes]:
 
 
 def branches_with_remote_upstreams() -> List[Branch]:
-    raw_bytes = check_output(["git", "branch", "--format=%(refname) %(upstream)"])
+    raw_bytes = check_output(
+        ["git", "for-each-ref", "--format=%(refname) %(upstream)", "refs/heads"]
+    )
     return [
         Branch(name=name, upstream=upstream)
         for name, upstream in (line.split(b" ") for line in raw_bytes.splitlines())
@@ -31,7 +33,7 @@ def branches_with_remote_upstreams() -> List[Branch]:
 
 def get_remote_branches(remote: bytes) -> List[bytes]:
     return check_output(
-        ["git", "branch", "--list", "-r", remote + b"/*", "--format=%(refname)"]
+        ["git", "for-each-ref", "--format=%(refname)", b"refs/remotes/" + remote]
     ).splitlines()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-sync"
-version = "0.1.1"
+version = "0.1.2"
 description = "Synchronize local git repo with remotes"
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 


### PR DESCRIPTION
This fixes #5, where git-branch can output additional user-targeted information that our script cannot parse