### PR TITLE
Do not fetch current branch

### DIFF
--- a/git_sync/git.py
+++ b/git_sync/git.py
@@ -123,7 +123,7 @@ async def fetch_and_fast_forward_to_upstream(branches: Iterable[Branch]) -> None
         await git("pull", "--all")
     else:
         await git("fetch", "--all")
-    fetch_args = [b.upstream + b":" + b.name for b in branches]
+    fetch_args = [b.upstream + b":" + b.name for b in branches if not b.is_current]
     if fetch_args:
         # Ignore return code as fetch will exit with a non-zero code if any
         # branch cannot be fast-forwarded, which is not a failing state for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-sync"
-version = "0.2.0"
+version = "0.2.1"
 description = "Synchronize local git repo with remotes"
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 


### PR DESCRIPTION
Fix bug introduced by #12, where the current branch was no longer being filtered out of the list of branches to update with fetch after doing a git pull.