### PR TITLE
Skip PRs with no commit data

### DIFF
--- a/git_sync/github.py
+++ b/git_sync/github.py
@@ -110,12 +110,13 @@ async def fetch_pull_requests_from_domain(
         for pr_data in repo_data["pullRequests"]["nodes"]:
             head_repo = pr_data.get("headRepository") or {}
             repo_urls = [head_repo.get("sshUrl"), head_repo.get("url")]
-            yield PullRequest(
-                branch_name=pr_data["headRefName"],
-                repo_urls=frozenset(url for url in repo_urls if url is not None),
-                branch_hash=pr_data["commits"]["nodes"][0]["commit"]["oid"],
-                merged_hash=(pr_data.get("mergeCommit") or {}).get("oid"),
-            )
+            if pr_data["commits"]["nodes"]:
+                yield PullRequest(
+                    branch_name=pr_data["headRefName"],
+                    repo_urls=frozenset(url for url in repo_urls if url is not None),
+                    branch_hash=pr_data["commits"]["nodes"][0]["commit"]["oid"],
+                    merged_hash=(pr_data.get("mergeCommit") or {}).get("oid"),
+                )
 
 
 async def fetch_pull_requests(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-sync"
-version = "0.2.2"
+version = "0.2.3"
 description = "Synchronize local git repo with remotes"
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 


### PR DESCRIPTION
Apparently not all PRs have commit data. Fix a crash that occurs in this case.

```text
  File "git_sync/github.py", line 116, in fetch_pull_requests_from_domain
    branch_hash=pr_data["commits"]["nodes"][0]["commit"]["oid"],                                                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```