### PR TITLE
Respect git config for proxy/sslcainfo

### DIFF
--- a/git_sync/__init__.py
+++ b/git_sync/__init__.py
@@ -18,7 +18,7 @@ from .github import fetch_pull_requests, repos_by_domain
 
 
 def github_token_envvar(domain: str) -> str:
-    return domain.split(".")[0].upper() + "_TOKEN"
+    return domain.split(".", maxsplit=1)[0].upper() + "_TOKEN"
 
 
 def github_token(domain: str) -> str | None:

--- a/git_sync/github.py
+++ b/git_sync/github.py
@@ -1,6 +1,7 @@
 import re
 import ssl
 from asyncio import Semaphore, gather
+from asyncio.subprocess import PIPE, create_subprocess_exec
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any, TypeVar
@@ -104,10 +105,33 @@ def join_queries(queries: Iterable[str]) -> str:
     return "{" + "\n".join(f"q{i}: {query}" for i, query in enumerate(queries)) + "}"
 
 
-def client_session() -> aiohttp.ClientSession:
+async def get_http_config(url: str) -> dict[str, str]:
+    """Read git http.* config applicable to the given URL.
+
+    Uses --get-urlmatch to respect domain-specific overrides.
+    """
+    proc = await create_subprocess_exec(
+        "git", "config", "--get-urlmatch", "http", url, stdout=PIPE
+    )
+    assert proc.stdout
+    raw = await proc.stdout.read()
+    await proc.wait()
+    result: dict[str, str] = {}
+    for line in raw.rstrip(b"\r\n").splitlines():
+        key, _, value = line.partition(b" ")
+        result[key.decode("ascii").lower()] = value.decode()
+    return result
+
+
+def client_session(
+    *, proxy: str | None = None, ssl_ca_info: str | None = None
+) -> aiohttp.ClientSession:
     """Configure aiohttp to trust local SSL credentials and environment variables."""
-    connector = aiohttp.TCPConnector(ssl=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
-    return aiohttp.ClientSession(trust_env=True, connector=connector)
+    ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if ssl_ca_info:
+        ssl_context.load_verify_locations(cafile=ssl_ca_info)
+    connector = aiohttp.TCPConnector(ssl=ssl_context)
+    return aiohttp.ClientSession(trust_env=True, connector=connector, proxy=proxy)
 
 
 def repo_urls(pr_data: dict[str, Any]) -> Iterator[str]:
@@ -128,7 +152,11 @@ async def fetch_pull_requests_from_domain(
         else f"https://{domain}/api/graphql"
     )
 
-    async with client_session() as session:
+    http_config = await get_http_config(f"https://{domain}")
+    proxy = http_config.get("http.proxy")
+    ssl_ca_info = http_config.get("http.sslcainfo")
+
+    async with client_session(proxy=proxy, ssl_ca_info=ssl_ca_info) as session:
         client = GraphQLClient(
             endpoint=endpoint,
             headers={"Authorization": f"Bearer {token}"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "git-sync"
-version = "0.4.3"
+version = "0.5.0"
 description = "Synchronize local git repo with remotes"
 authors = [{ name = "Alice Purcell", email = "alicederyn@gmail.com" }]
 requires-python = ">= 3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dynamic = ["dependencies"]
 git-sync = "git_sync:main"
 
 [tool.mypy]
+files = ["git_sync", "tests"]
 python_version = "3.12"
 strict = true
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,6 +5,8 @@ import pytest
 
 from git_sync.github import PullRequest, Repository, fetch_pull_requests_from_domain
 
+MOCK_HTTP_CONFIG = "git_sync.github.get_http_config"
+
 TWO_REPOS = [
     Repository(domain="github.com", owner="owner1", name="repo1"),
     Repository(domain="github.com", owner="owner2", name="repo2"),
@@ -24,12 +26,24 @@ def graphql_client() -> Iterator[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def client_session() -> Iterator[Mock]:
+def http_config() -> Iterator[Mock]:
+    with patch(MOCK_HTTP_CONFIG, new_callable=AsyncMock, return_value={}) as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def client_session_factory() -> Iterator[Mock]:
     session = Mock(name="client_session")
     with patch("git_sync.github.client_session") as mock:
         mock.return_value.__aenter__ = AsyncMock(return_value=session)
         mock.return_value.__aexit__ = AsyncMock(return_value=None)
-        yield session
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def client_session(client_session_factory: Mock) -> Mock:
+    session: Mock = client_session_factory.return_value.__aenter__.return_value
+    return session
 
 
 async def test_successful_fetch_with_multiple_repos_and_prs(
@@ -243,3 +257,33 @@ async def test_graphql_errors(graphql_client: Mock) -> None:
     with pytest.raises(RuntimeError, match="GraphQL query failed:"):
         async for _ in fetch_pull_requests_from_domain(Mock(), Mock(), TWO_REPOS):
             pass
+
+
+async def test_git_config_proxy_passed_to_session(
+    http_config: Mock, client_session_factory: Mock
+) -> None:
+    http_config.return_value = {
+        "http.proxy": "http://proxy:8080",
+        "http.sslcainfo": "/path/to/ca.pem",
+    }
+
+    async for _ in fetch_pull_requests_from_domain(
+        "test-token", "github.com", TWO_REPOS
+    ):
+        pass
+
+    http_config.assert_called_once_with("https://github.com")
+    client_session_factory.assert_called_once_with(
+        proxy="http://proxy:8080", ssl_ca_info="/path/to/ca.pem"
+    )
+
+
+async def test_git_config_no_proxy_passed_as_none(
+    client_session_factory: Mock,
+) -> None:
+    async for _ in fetch_pull_requests_from_domain(
+        "test-token", "github.com", TWO_REPOS
+    ):
+        pass
+
+    client_session_factory.assert_called_once_with(proxy=None, ssl_ca_info=None)


### PR DESCRIPTION
When accessing github via graphql, first check the git configuration for any proxy-related settings, to work transparently behind a corporate firewall.